### PR TITLE
Hotfix/containerd restart

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 copy_kubeconfig: true
-kubernetes_version: "1.31"
-crio_version: "1.31"
+kubernetes_version: "1.32"
+crio_version: "1.32"
 container_runtime: "crio"
 metallb_ip_range: ""
 

--- a/tasks/worker-node.yml
+++ b/tasks/worker-node.yml
@@ -12,7 +12,9 @@
   ansible.builtin.systemd:
     name: containerd
     state: restarted
-  when: "'k8s_worker' in group_names"
+  when:
+    - "'k8s_worker' in group_names"
+    - container_runtime == 'containerd'
 
 - name: Check if node has been initialized
   stat:


### PR DESCRIPTION
This pull request includes updates to the Kubernetes and CRI-O versions, as well as a conditional check enhancement for restarting the `containerd` service.

Version updates:

* [`defaults/main.yml`](diffhunk://#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4L3-R4): Updated `kubernetes_version` and `crio_version` from "1.31" to "1.32".

Conditional check enhancement:

* [`tasks/worker-node.yml`](diffhunk://#diff-599adce5af1d462b367c487248f1667d555645272b8ef53f39117b001c778265L15-R17): Added an additional condition to check if `container_runtime` is 'containerd' before restarting the `containerd` service.